### PR TITLE
Removed french characters in comments

### DIFF
--- a/canvec2016.py
+++ b/canvec2016.py
@@ -59,12 +59,12 @@ def roadClassLookup(roadclass_identifier):
 		tags['bus'] = 'yes'
 	elif roadclass_identifier == 317:
 		# Resource-Recreation Cart Track
-		# Définition à venir
+		# TODO
 		tags['highway'] = 'raceway'
 		tags['sport'] = 'karting'
 	elif roadclass_identifier in [318, 319, 320]:
 		# Resource-Recreation Dry Weather
-		# Définition à venir
+		# TODO
 		tags['highway'] = 'raceway'
 	elif roadclass_identifier == 312:
 		# Service Lane


### PR DESCRIPTION
running on Python 2.7.10

Error:

```
$ python ogr2osm.py -t canvec.py canvec_50K_NT_Transport_shp/road_segment_1.shp
running with ElementTree on Python 2.5+
Preparing to convert 'canvec_50K_NT_Transport_shp/road_segment_1.shp' to '/Users/mac/Github/ogr2osm/road_segment_1.osm'.
Will try to detect projection from source metadata, or fall back to EPSG:4326
Usage: ogr2osm.py SRCFILE

SRCFILE can be a file path or a org PostgreSQL connection string such as:
"PG:dbname=pdx_bldgs user=emma host=localhost" (including the quotes)

ogr2osm.py: error: Syntax error in 'canvec'. Translation script is malformed:
Non-ASCII character '\xc3' in file canvec.py on line 62, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details (canvec.py, line 62)
```
